### PR TITLE
Feature : 테마 객체 타입 정의추가

### DIFF
--- a/src/shared/config/theme.d.ts
+++ b/src/shared/config/theme.d.ts
@@ -1,8 +1,0 @@
-import 'styled-components';
-import theme from './theme';
-
-type CustomTheme = typeof theme;
-
-declare module 'styled-components' {
-  export interface DefaultTheme extends CustomTheme {}
-}

--- a/src/shared/config/theme.ts
+++ b/src/shared/config/theme.ts
@@ -1,4 +1,4 @@
-const theme = {
+const rawTheme = {
   colors: {
     point1: '#2AC1BC',
     point2: '#D4F3F2',
@@ -77,4 +77,7 @@ const theme = {
     },
   },
 };
+
+type ThemeType = typeof rawTheme;
+const theme: ThemeType = rawTheme;
 export default theme;

--- a/src/shared/config/theme.ts
+++ b/src/shared/config/theme.ts
@@ -1,4 +1,89 @@
-const rawTheme = {
+import 'styled-components';
+import { DefaultTheme } from 'styled-components';
+
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    colors: {
+      point1: string;
+      point2: string;
+      point3: string;
+      white: string;
+      black: string;
+      grey1: string;
+      grey2: string;
+      orange: string;
+      red: string;
+      green: string;
+    };
+    typography: {
+      heading1: {
+        fontSize: string;
+        fontWeight: number;
+        fontFamily: string;
+        letterSpacing: string;
+        lineHeight: string;
+      };
+      heading2: {
+        fontSize: string;
+        fontWeight: number;
+        fontFamily: string;
+        letterSpacing: string;
+        lineHeight: string;
+      };
+      heading3: {
+        fontSize: string;
+        fontWeight: number;
+        fontFamily: string;
+        letterSpacing: string;
+        lineHeight: string;
+      };
+      heading4: {
+        fontSize: string;
+        fontWeight: number;
+        fontFamily: string;
+        letterSpacing: string;
+        lineHeight: string;
+      };
+      menu1: {
+        fontSize: string;
+        fontWeight: number;
+        fontFamily: string;
+        letterSpacing: string;
+        lineHeight: string;
+      };
+      body1: {
+        fontSize: string;
+        fontWeight: number;
+        fontFamily: string;
+        letterSpacing: string;
+        lineHeight: string;
+      };
+      body2: {
+        fontSize: string;
+        fontWeight: number;
+        fontFamily: string;
+        letterSpacing: string;
+        lineHeight: string;
+      };
+      body3: {
+        fontSize: string;
+        fontWeight: number;
+        fontFamily: string;
+        letterSpacing: string;
+        lineHeight: string;
+      };
+      body4: {
+        fontSize: string;
+        fontWeight: number;
+        fontFamily: string;
+        letterSpacing: string;
+        lineHeight: string;
+      };
+    };
+  }
+}
+
+export const theme: DefaultTheme = {
   colors: {
     point1: '#2AC1BC',
     point2: '#D4F3F2',
@@ -77,7 +162,3 @@ const rawTheme = {
     },
   },
 };
-
-type ThemeType = typeof rawTheme;
-const theme: ThemeType = rawTheme;
-export default theme;


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #11 

## 📝 Task Details

- 기존 타입 선언 파일 삭제
- 새롭게 객체의 타입을 정의하기(DefaultTheme)

## 📂 References

- https://lasbe.tistory.com/168#google_vignette
- 정의한 테마의 속성을 선언하기 위해 다음 과정을 진행하였습니다.

<img width="676" alt="스크린샷 2025-02-28 오전 2 10 34" src="https://github.com/user-attachments/assets/211a6140-ac9d-4cfe-9d18-15828bebdbb0" />

## 💖 Review Requirements

스타일드 컴포넌트 내에서 사용할 경우 

ex) 

${(theme) => theme.typography.heading3}
