### PR TITLE
Feat : 회원가입 시에 급여 내역 정보 기본값 저장

### DIFF
--- a/src/features/auth/useSignUp.ts
+++ b/src/features/auth/useSignUp.ts
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify';
 
 import { FirebaseError } from 'firebase/app';
 import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
-import { doc, setDoc } from 'firebase/firestore';
+import { addDoc, collection, doc, setDoc, Timestamp } from 'firebase/firestore';
 import { auth, db } from '@/firebase';
 
 interface SignUpType {
@@ -42,7 +42,7 @@ const useSignUp = () => {
 
       const user = createdUser.user;
 
-      // 임시 데이터
+      // 기본 인사 정보데이터
       const userData = {
         name: user.displayName,
         email: user.email,
@@ -53,6 +53,37 @@ const useSignUp = () => {
 
       // Firestore에 유저 정보 저장
       await setDoc(doc(db, 'users', user.uid), userData);
+
+      // 2025년 1월 15일, 2월 15일, 3월 15일 날짜 생성
+      const specificDates = [
+        new Date(2025, 0, 15),
+        new Date(2025, 1, 15),
+        new Date(2025, 2, 15),
+      ];
+
+      // 각 날짜에 대해 Timestamp로 변환 후 저장
+      const salaryData = specificDates.map((date) => {
+        return {
+          actualPayment: 4600000, // 실지급액
+          base: 3000000, // 기본급
+          bonus: 500000, // 상여금
+          care: -50000, // 예시로 공제 항목 설정
+          date: Timestamp.fromDate(date), // 날짜를 Timestamp로 변환
+          health: -150000, // 예시로 공제 항목 설정
+          job: -80000, // 예시로 공제 항목 설정
+          night: 100000, // 예시로 야근수당 설정
+          overtime: 200000, // 예시로 초과근무수당 설정
+          position: 300000, // 직급
+          tax: -120000, // 세금
+          totalDeduct: -400000, // 공제합계
+          totalPayment: 5000000, // 지급합계
+        };
+      });
+
+      // Firestore에 급여 내역 정보 저장
+      for (const data of salaryData) {
+        await addDoc(collection(db, 'users', user.uid, 'salary'), data);
+      }
 
       toast.success('회원가입 성공!');
       navigate('/');

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -66,7 +66,7 @@ const SignUp = () => {
                   },
                 })}
                 type="password"
-                placeholder="사용할 비밀번호를 입력하세요(8자리 이상, 특수문자 포함)"
+                placeholder="사용할 비밀번호를 입력하세요(8자리 이상)"
                 hasError={!!errors.password}
               />
               {errors.password && (
@@ -83,7 +83,7 @@ const SignUp = () => {
                     '비밀번호가 일치하지 않습니다.',
                 })}
                 type="password"
-                placeholder="비밀번호를 다시 입력하세요(8자리 이상, 특수문자 포함)"
+                placeholder="비밀번호를 다시 입력하세요(8자리 이상)"
                 hasError={!!errors.pwdCheck}
               />
               {errors.pwdCheck && (


### PR DESCRIPTION
## ✨ Related Issues

- 이슈 넘버 #[issue_number]

## 📝 Task Details

- 파이어베이스 콘솔 내에서 test@naver.com 계정에 급여 내역 정보 기본값을 저장해두려고 했으나, 번거로운 점과 테스트 계정 이외 계정에서도 기본 급여 내역이 뜰 수 있도록 회원가입 시에 자동으로 저장되는 로직을 추가하였습니다.
- 2025/01/15, 2025/02/15, 2025/03/15 총 세 개의 급여 내역을 저장합니다.

##  📢 논의 사항
- 따라서, test 계정을 전달드릴지 아니면 멘토님이 직접 회원가입을 진행하게 할지 내일 오전에 논의가 필요해보입니다!

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💖 Review Requirements

- 지원님 급여 내역과 모달 내에서 구현해두신 정보가 잘 뜨는지 확인바랍니다!
